### PR TITLE
Fix: Fetch fn on main page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,7 +5,7 @@ import CroockedContainer from '../components/ui-elements/containers/croocked-con
 import { GitHubUserRepo } from '../types/api/github-user-data.type';
 
 export async function getServerSideProps() {
-  const fetchGitHubData = await fetch(`http://localhost:3000/api/github`);
+  const fetchGitHubData = await fetch(`${process.env.BASE_URL}/api/github`);
   const data: GitHubUserRepo[] = await fetchGitHubData.json();
 
   return {


### PR DESCRIPTION
Fetch function held development localhost rather than dynamic base_url var