### PR TITLE
Scroll to top on menu trigger

### DIFF
--- a/components/header/menu.tsx
+++ b/components/header/menu.tsx
@@ -18,6 +18,14 @@ interface MenuProps {
 
 const Menu = ({ toggleAnimation, onToggle, isOnDom }: MenuProps) => {
   useEffect(() => {
+    /**
+     * This useEffect makes sure coule of things:
+     *
+     * - Scroll for X axis and Y axis are hidden.
+     * - When ever menu is triggered (open / close) user scrolled to top.
+     */
+
+    window.scrollTo({ top: 0, behavior: 'smooth' });
     if (isOnDom) {
       document.body.classList.add('overflow-hidden');
     } else {


### PR DESCRIPTION
Even though a bug fix was merged, still if the user has some space to both but out-of-screen height and able to click the menu button, the menu was still seemed "floating" or unattached, added window.scollTo to fix that.